### PR TITLE
Don't use types as traits in macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ mod test {
     macro_rules! test_mod {
         (
             $test_name:ident,
-            trait $base_trait:ty { $($base_impl:tt)* },
+            trait $base_trait:path { $($base_impl:tt)* },
             type $base_type:ty,
             { $($def:tt)+ }
         ) => {
@@ -296,7 +296,7 @@ mod test {
 
         (
             $test_name:ident,
-            trait $base_trait:ty { $($base_impl:tt)* },
+            trait $base_trait:path { $($base_impl:tt)* },
             { $($def:tt)+ }
         ) => {
             test_mod! {


### PR DESCRIPTION
Hello.

We've found that this crate is affected by an upcoming bugfix in `rustc` - https://github.com/rust-lang/rust/pull/48502 (`ty` fragments are no longer accepted as traits in trait impls).
This PR fixes the deprecated use of `ty`.