### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ Trait object downcasting support using only safe Rust. It supports type
 parameters, associated types, and type constraints.
 """
 readme = "README.md"
-keywords = ["downcast", "any", "trait", "associated", "constraint"]
+keywords = ["downcast", "any", "trait", "associated", "constraint", "no_std"]
 license = "MIT/Apache-2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+#![feature(alloc)]
 #![deny(unsafe_code)]
 //! Rust enums are great for types where all variations are known beforehand. But in
 //! the case where you want to implement a container of user-defined types, an
@@ -117,7 +119,15 @@
 //! }
 //! ```
 
-use std::any::Any;
+
+#[cfg(not(test))]
+extern crate alloc as std;
+
+#[cfg(test)]
+extern crate std;
+
+use core::any::Any;
+use std::boxed::Box;
 
 /// Supports conversion to `Any`. Traits to be extended by `impl_downcast!` must extend `Downcast`.
 pub trait Downcast: Any {


### PR DESCRIPTION
This PR turns `downcast-rs` into a `no_std` crate.

Pros: `no_std` environments could directly use this crate from crates.io.
Cons: Currently the `stable` branch of Rust cannot compile it because `feature(alloc)` is unstable now. To compile it using rust stable, one should set env var `RUSTC_BOOTSTRAP=1` to turn on the `alloc` feature gate.

p.s. `cargo test` would fail at `doctest` due to missing `GlobalAllocator`, while `cargo doc` success.

Signed-off-by: dingelish <dingelish@gmail.com>