### PR TITLE
Support no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+      - name: Docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+      - name: Build for no_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features
+      - name: Test for no_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+      - name: Clippy for no_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features
+      - name: Docs for no_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.1 - 2019-10-28
+### Changed
+- Used `dyn Trait` syntax everywhere since it is supported by downcast-rs's
+  min-supported rust version (1.33).
+
 ## 1.1.0 - 2019-10-07
 ### Added
 - Support for downcasting `Rc<Trait>` and `Arc<Trait>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "downcast-rs"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Ashish Myles <marcianx@gmail.com>"]
 repository = "https://github.com/marcianx/downcast-rs"
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ Trait object downcasting support using only safe Rust. It supports type
 parameters, associated types, and type constraints.
 """
 readme = "README.md"
-keywords = ["downcast", "any", "trait", "associated", "constraint"]
+keywords = ["downcast", "any", "trait", "associated", "constraint", "no_std"]
 license = "MIT/Apache-2.0"
 
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # downcast-rs
 
+[![Build status](https://img.shields.io/github/workflow/status/marcianx/downcast-rs/CI/master)](https://github.com/marcianx/downcast-rs/actions)
+[![Latest version](https://img.shields.io/crates/v/downcast-rs.svg)](https://crates.io/crates/downcast-rs)
+[![Documentation](https://docs.rs/downcast-rs/badge.svg)](https://docs.rs/downcast-rs)
+
 Rust enums are great for types where all variations are known beforehand. But a
 container of user-defined types requires an open-ended type like a **trait
 object**. Some applications may want to cast these trait objects back to the
@@ -8,6 +12,22 @@ inlined implementations.
 
 `downcast-rs` adds this downcasting support to trait objects using only safe
 Rust. It supports **type parameters**, **associated types**, and **constraints**.
+
+## Usage
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+downcast-rs = "1.1.1"
+```
+
+This crate is `no_std` compatible. To use it without `std`:
+
+```toml
+[dependencies]
+downcast-rs = { version = "1.1.1", default-features = false }
+```
 
 To make a trait downcastable, make it extend either `downcast::Downcast` or
 `downcast::DowncastSync` and invoke `impl_downcast!` on it as in the examples


### PR DESCRIPTION
Now feature `alloc` is available in stable Rust.
It's time to make it `no_std` compatible.

Similar to PR #5 .