### PR TITLE
Update shields badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # downcast-rs
 
-[![Build status](https://img.shields.io/github/workflow/status/marcianx/downcast-rs/CI/master)](https://github.com/marcianx/downcast-rs/actions)
+[![Build status](https://img.shields.io/github/actions/workflow/status/marcianx/downcast-rs/main.yml?branch=master)](https://github.com/marcianx/downcast-rs/actions)
 [![Latest version](https://img.shields.io/crates/v/downcast-rs.svg)](https://crates.io/crates/downcast-rs)
 [![Documentation](https://docs.rs/downcast-rs/badge.svg)](https://docs.rs/downcast-rs)
 


### PR DESCRIPTION
https://github.com/badges/shields/issues/8671

Also, the last commit is from 2020 by now and makes people think this crate is abandoned ([Discord link](https://discord.com/channels/273534239310479360/274215136414400513/1108118629393895515)). A recent commit would stop this misconception, so this PR is doubly useful :)