### PR TITLE
Make `DowncastSync` Optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ keywords = ["downcast", "any", "trait", "associated", "no_std"]
 license = "MIT/Apache-2.0"
 
 [features]
-default = ["std"]
+default = ["std", "sync"]
 std = []
+sync = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
 //!
 //! Since 1.2.0, the minimum supported Rust version is 1.36 due to needing stable access to alloc.
 //!
-//! ```
+#![cfg_attr(feature = "sync", doc = "```")]
+#![cfg_attr(not(feature = "sync"), doc = "```ignore")]
 //! # #[macro_use]
 //! # extern crate downcast_rs;
 //! # use downcast_rs::{Downcast, DowncastSync};
@@ -72,7 +73,8 @@
 //!
 //! # Example without generics
 //!
-//! ```
+#![cfg_attr(feature = "sync", doc = "```")]
+#![cfg_attr(not(feature = "sync"), doc = "```ignore")]
 //! # use std::rc::Rc;
 //! # use std::sync::Arc;
 //! // Import macro via `macro_use` pre-1.30.
@@ -168,7 +170,10 @@ pub extern crate std as __std;
 pub extern crate alloc as __alloc;
 
 use __std::any::Any;
-use __alloc::{boxed::Box, rc::Rc, sync::Arc};
+use __alloc::{boxed::Box, rc::Rc};
+
+#[cfg(feature = "sync")]
+use __alloc::sync::Arc;
 
 /// Supports conversion to `Any`. Traits to be extended by `impl_downcast!` must extend `Downcast`.
 pub trait Downcast: Any {
@@ -193,6 +198,7 @@ impl<T: Any> Downcast for T {
     fn as_any_mut(&mut self) -> &mut dyn Any { self }
 }
 
+#[cfg(feature = "sync")]
 /// Extends `Downcast` to support `Sync` traits that thus support `Arc` downcasting as well.
 pub trait DowncastSync: Downcast + Send + Sync {
     /// Convert `Arc<Trait>` (where `Trait: Downcast`) to `Arc<Any>`. `Arc<Any>` can then be
@@ -200,6 +206,7 @@ pub trait DowncastSync: Downcast + Send + Sync {
     fn into_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 }
 
+#[cfg(feature = "sync")]
 impl<T: Any + Send + Sync> DowncastSync for T {
     fn into_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> { self }
 }
@@ -420,7 +427,7 @@ macro_rules! impl_downcast {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sync"))]
 mod test {
     macro_rules! test_mod {
         (


### PR DESCRIPTION
# Objective

Currently, `downcast-rs` does not compile on platforms which lack `Arc` support, such as `thumbv6m-none-eabi` (e.g., the Raspberry Pi Pico). Crates like `portable-atomic-util` can provide a compatibility shim, but without RFC [#982](https://github.com/rust-lang/rust/issues/18598), and RFC [#3519](https://github.com/rust-lang/rust/issues/44874), the ergonomics would be vastly different with and without `portablie-atomic`.

# Solution

Added a feature flag for `DowncastSync`, `sync`. Since it is the only part of `downcast-rs` that relies on `Arc`, disabling just it alone is sufficient to allow compilation on `thumbv6m-none-eabi` and other atomically challenged platforms. This does constitute a breaking change for users who disable default features, as they will have to enable the `sync` feature to retain existing functionality.

# Alternatives

Wait for the above RFCs to be stabilised and then use `portable-atomic` instead.

# Notes

This is my first time contributing to this project. Please let me know if there's anything I can do to assist with evaluating this PR.